### PR TITLE
Docs Fix

### DIFF
--- a/源/root.md
+++ b/源/root.md
@@ -2,9 +2,10 @@
 
 ## 安卓5
 ```bash
-deb https://termux.org/termux-root-packages-21-bin root stable
+deb https://termux.dev/termux-root-packages-21-bin root stable
 ```
 
 ## 安卓7
 ```bash
-deb https://packages-cf.termux.org/apt/termux-root/ root stable
+deb https://packages-cf.termux.dev/apt/termux-root/ root stable
+```

--- a/源/不稳定.md
+++ b/源/不稳定.md
@@ -5,3 +5,8 @@
 ```bash
 deb https://packages-cf.termux.dev/apt/termux-unstable/ unstable stable
 ```
+
+目前，不稳定仓库仅仅是一个空仓库。以前所有不稳定仓库中可用的软件包已经合并到了
+主仓库，不能使用的包也已经合并进了主仓库的 `disabled-packages` 文件夹中。不
+稳定仓库 URL 的存在仅仅是为了保证兼容性。参见：
+[unstable-packages/README.md](https://gitlab.com/termux-mirror/unstable-packages/-/blob/master/README.md)  

--- a/源/不稳定.md
+++ b/源/不稳定.md
@@ -3,4 +3,5 @@
 ## 安卓7
 
 ```bash
-deb https://packages-cf.termux.org/apt/termux-unstable/ unstable stable
+deb https://packages-cf.termux.dev/apt/termux-unstable/ unstable stable
+```

--- a/源/主源.md
+++ b/源/主源.md
@@ -2,10 +2,10 @@
 
 ## 安卓5
 ```bash
-deb https://packages-cf.termux.org/termux-main-21 stable main
+deb https://packages-cf.termux.dev/termux-main-21 stable main
 ```
 
 ## 安卓7
 ```bash
-deb https://packages-cf.termux.org/apt/termux-main/ stable main
+deb https://packages-cf.termux.dev/apt/termux-main/ stable main
 ```

--- a/源/安卓5源.md
+++ b/源/安卓5源.md
@@ -2,15 +2,15 @@
 
 
 ```bash
-deb https://packages-cf.termux.org/termux-main-21 stable main
-deb https://termux.org/game-packages-21-bin games stable
-deb https://termux.org/science-packages-21-bin sciense stable
+deb https://packages-cf.termux.dev/termux-main-21 stable main
+deb https://termux.dev/game-packages-21-bin games stable
+deb https://termux.dev/science-packages-21-bin sciense stable
 ```
 
 ## Root
 
 ```bash
-deb https://termux.org/termux-root-packages-21-bin root stable
+deb https://termux.dev/termux-root-packages-21-bin root stable
 ```
 
 **安卓5源暂时没有x11！**

--- a/源/游戏.md
+++ b/源/游戏.md
@@ -2,10 +2,10 @@
 
 ## 安卓5
 ```shell
-deb https://termux.org/game-packages-21-bin games stable
+deb https://termux.dev/game-packages-21-bin games stable
 ```
 
 ## 安卓7
 ```shell
-deb https://packages-cf.termux.org/apt/termux-games/ games stable
+deb https://packages-cf.termux.dev/apt/termux-games/ games stable
 ```

--- a/源/科学.md
+++ b/源/科学.md
@@ -2,10 +2,10 @@
 
 ## 安卓5
 ```bash
-deb https://termux.org/science-packages-21-bin sciense stable
+deb https://termux.dev/science-packages-21-bin sciense stable
 ```
 
 ## 安卓7
 ```bash
-deb https://packages-cf.termux.org/apt/termux-science/ sciense stable
+deb https://packages-cf.termux.dev/apt/termux-science/ sciense stable
 ```


### PR DESCRIPTION
* docs: 切换网址 `termux.org` 到 `termux.dev`

从 https://github.com/termux/termux-packages/commit/6cf9f35fac9ee124e99d58cc46f323f2c1014f4c 开始，`Termux` 应该会主要使用域名 `termux.dev` 而不是 `termux.org`。目前访问 `termux.org` 的相关网页会重定向到 `termux.dev`。

* docs: 为 unstable repo 添加注释信息

目前，不稳定仓库已经合并进主仓库，不稳定仓库指向的URL仅仅是一个空仓库。